### PR TITLE
Fix Error (undefined method `empty?' for #<Encoding:UTF-8>

### DIFF
--- a/lib/page_meta/meta_tag/charset.rb
+++ b/lib/page_meta/meta_tag/charset.rb
@@ -2,7 +2,7 @@ module PageMeta
   class MetaTag
     class Charset < MetaTag
       def render
-        return if content.empty?
+        return if content.blank?
 
         helpers.tag(:meta, charset: content)
       end


### PR DESCRIPTION
Fix provided by @dedman as an answer to the issue I opened a few days ago.
https://github.com/fnando/page_meta/issues/3#issuecomment-330365622

The Encoding class does not implement the `empty?` method as it directly inherits from Object.
It does respond to `blank?` however, which is conveniently added by Rails.
(For the curious reader, I just learnt about that by reading https://blog.arkency.com/2017/07/nil-empty-blank-ruby-rails-difference/.)