### PR TITLE
Fixed charset meta tag

### DIFF
--- a/lib/page_meta/meta_tag/charset.rb
+++ b/lib/page_meta/meta_tag/charset.rb
@@ -2,7 +2,7 @@ module PageMeta
   class MetaTag
     class Charset < MetaTag
       def render
-        return if content.empty?
+        return if content.blank?
 
         helpers.tag(:meta, charset: content)
       end

--- a/lib/page_meta/meta_tag/charset.rb
+++ b/lib/page_meta/meta_tag/charset.rb
@@ -4,7 +4,7 @@ module PageMeta
       def render
         return if content.blank?
 
-        helpers.tag(:meta, charset: content)
+        helpers.tag(:meta, charset: content.to_s.upcase)
       end
     end
   end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -8,7 +8,7 @@ class PagesControllerTest < ActionController::TestCase
 
   test "render encoding tag" do
     get :show
-    assert_select "meta[charset=utf-8]"
+    assert_select "meta[charset=UTF-8]"
   end
 
   test "render language tag" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
-require "codeclimate-test-reporter"
-CodeClimate::TestReporter.start
+require 'simplecov'
+SimpleCov.start
 
 require "bundler/setup"
 require "test_notifier"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
-require 'simplecov'
+require "simplecov"
 SimpleCov.start
 
 require "bundler/setup"


### PR DESCRIPTION
There was a bug rendering charset meta tag. The Encoding object doesn't have 'empty?' method anymore.

Code Climate was fixed too, based on v1.0.0 changes (2016-11-03):
https://github.com/codeclimate/ruby-test-reporter/blob/master/CHANGELOG.md#v100-2016-11-03